### PR TITLE
enc: add ability to hide file view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,11 +37,12 @@ function App() {
   )
 
   // transient editor state
-  const { showSettings, showPreview, setArbitraryEditorState } = useEditorStateStore(
+  const { showSettings, showPreview, fileView, setArbitraryEditorState } = useEditorStateStore(
     useShallow((s) => ({
       showSettings: s.showSettings,
       setArbitraryEditorState: s.setArbitrary,
-      showPreview: s.showPreview
+      showPreview: s.showPreview,
+      fileView: s.fileView
     }))
   )
 
@@ -153,7 +154,7 @@ function App() {
     <>
       <TopBar />
       <Stack spacing='none' style={{ width: '100vw', flex: '1' }}>
-        <FileViewer></FileViewer>
+        {fileView && <FileViewer />}
         <CodeMirrorEditor
           className={showPreview ? 'hide-me' : ''}
           code={localText}

--- a/src/components/FirstTime/FirstTime.tsx
+++ b/src/components/FirstTime/FirstTime.tsx
@@ -11,9 +11,10 @@ const KEYBINDS: KeyBindProps[] = [
     cmd: 'ctrl + M',
     desc: 'Open the settings menu'
   },
-  { cmd: 'ctrl + B', desc: 'Toggle preview mode' },
-  { cmd: 'ctrl + l', desc: 'Toggle line numbers' },
-  { cmd: 'ctrl + s', desc: 'Save current file to disk' }
+  { cmd: 'ctrl + B', desc: 'Toggle file view' },
+  { cmd: 'ctrl + D', desc: 'Toggle preview view' },
+  { cmd: 'ctrl + S', desc: 'Save current file to disk' },
+  { cmd: 'ctrl + L', desc: 'Toggle line numbers' }
 ]
 
 function KeyBind(props: { cmd: string; desc: string }) {
@@ -33,7 +34,7 @@ function KeyBind(props: { cmd: string; desc: string }) {
 export default function FirstTime() {
   return (
     <Stack dir='vertical'>
-      <p>Welcome to skib. A customizable Markdown editor for the browser.</p>
+      <p>Welcome to skrib. A customizable Markdown editor for the browser.</p>
 
       <h4>Keybinds</h4>
       {KEYBINDS.map((kb, index) => (

--- a/src/components/KeyCommands/KeyCommands.tsx
+++ b/src/components/KeyCommands/KeyCommands.tsx
@@ -41,8 +41,12 @@ const handleSaveFile: keyboardJs.Callback = async (e) => {
 }
 
 export default function KeyCommands() {
-  const { toggleSettings, togglePreview } = useEditorStateStore(
-    useShallow((s) => ({ toggleSettings: s.toggleSettings, togglePreview: s.togglePreview }))
+  const { toggleSettings, togglePreview, toggleFileView } = useEditorStateStore(
+    useShallow((s) => ({
+      toggleSettings: s.toggleSettings,
+      togglePreview: s.togglePreview,
+      toggleFileView: s.toggleFileView
+    }))
   )
 
   const { toggleLineNumbers } = useSettingsStore(
@@ -52,7 +56,11 @@ export default function KeyCommands() {
   )
 
   // define keybind actions
-  useKeyboardJsToggle('ctrl + b', togglePreview)
+  useKeyboardJsToggle('ctrl + b', toggleFileView)
+  useKeyboardJsToggle('ctrl + d', (e) => {
+    e?.preventDefault()
+    togglePreview()
+  })
   useKeyboardJsToggle('ctrl + m', toggleSettings)
   useKeyboardJsToggle('ctrl + l', (e) => {
     e?.preventDefault()

--- a/src/store/editor-state.ts
+++ b/src/store/editor-state.ts
@@ -19,7 +19,7 @@ export const DEF_SETTINGS: EditorState = {
   showPreview: false,
   showSettings: false,
   scrollPosition: 0,
-  fileView: false
+  fileView: true
 }
 
 const useEditorStateStore = create<EditorState & EditorMutate>((set) => ({


### PR DESCRIPTION
Changes:

- Add new transient state for file viewer to be opened and closed
- Switch keybind to be `ctrl + b` for toggle file view and `ctrl + d` for toggle preview
- Small typo in welcome modal