### PR TITLE
fix: disable grammarly on the editor

### DIFF
--- a/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
+++ b/src/components/CodeMirrorEditor/CodeMirrorEditor.tsx
@@ -139,7 +139,13 @@ export default function CodeMirrorEditor(props: CodeMirrorEditorProps) {
       foldGutter: false
     },
     extensions: [
-      EditorView.contentAttributes.of({ id: 'skrib-editor', 'aria-label': 'skrib-editor' }),
+      EditorView.contentAttributes.of({
+        id: 'skrib-editor',
+        'aria-label': 'skrib-editor',
+        'data-gram': 'false',
+        'data-gram_editor': 'false',
+        'data-enable-grammarly': 'false'
+      }),
       DEF_EDITOR_THEME,
       appliedTheme,
       showPanel.of(showInfoPanel ? wordCountPanel : null),


### PR DESCRIPTION
Changes:

- add attributes to the editor that disable the Grammarly plugin trying to spell correctly.